### PR TITLE
Add missing gfortran dependency in dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y  \
     bzip2 \
     g++ \
     git \
+    gfortran \
     gstreamer1.0-plugins-good \
     gstreamer1.0-tools \
     gstreamer1.0-pulseaudio \


### PR DESCRIPTION
I added gfortran to the docker file so the docker image would build properly on debian 10 aka buster.